### PR TITLE
[PR] Add events for mediaelement audio and video players

### DIFF
--- a/js/mediaelement-events.js
+++ b/js/mediaelement-events.js
@@ -1,0 +1,37 @@
+var _wpmejsSettings={
+	pluginPath: "/wp-includes/js/mediaelement/",
+	success: function( mejs ) {
+		//orginal default settings
+		var autoplay, loop;
+
+		if ( 'flash' === mejs.pluginType ) {
+			autoplay = mejs.attributes.autoplay && 'false' !== mejs.attributes.autoplay;
+			loop = mejs.attributes.loop && 'false' !== mejs.attributes.loop;
+
+			autoplay && mejs.addEventListener( 'canplay', function () {
+				mejs.play();
+			}, false );
+
+			loop && mejs.addEventListener( 'ended', function () {
+				mejs.play();
+			}, false );
+		}
+
+		if(typeof jQuery.jtrack !=="undefined"){
+			// Event listener for when the video starts playing
+			mejs.addEventListener( 'playing', function( e ) {
+				jQuery.jtrack.trackEvent(pageTracker,"Audio", 'playing');
+			}, false);
+
+			// Event listener for when the video is paused
+			mejs.addEventListener( 'pause', function( e ) {
+				jQuery.jtrack.trackEvent(pageTracker,"Audio", 'pausing');
+			}, false);
+
+			// Event listener for when the video ends
+			mejs.addEventListener( 'ended', function( e ) {
+				jQuery.jtrack.trackEvent(pageTracker,"Audio", 'ending');
+			}, false);
+		}
+	}
+};

--- a/wsu-analytics.php
+++ b/wsu-analytics.php
@@ -20,6 +20,7 @@ class WSU_Analytics {
 	 */
 	public function __construct() {
 		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
+		add_action( 'wp_enqueue_scripts', array( $this, 'mediaelement_scripts' ), 99 );
 		add_action( 'admin_init', array( $this, 'display_settings' ) );
 		add_action( 'wp_footer', array( $this, 'global_tracker' ), 999 );
 		add_action( 'admin_footer', array( $this, 'global_tracker' ), 999 );
@@ -99,6 +100,14 @@ class WSU_Analytics {
 
 		wp_localize_script( 'wsu-analytics-main', 'wsu_analytics', $tracker_data );
 		wp_enqueue_script( 'wsu-analytics-main' );
+	}
+
+	public function mediaelement_scripts() {
+		global $wp_scripts;
+		wp_deregister_script( 'wp-mediaelement' );
+		$wp_scripts->registered['mediaelement']->extra['data'] = str_replace( '_wpmejsSettings', '_oldwpmejsSettings', $wp_scripts->registered['mediaelement']->extra['data'] );
+		wp_enqueue_script( 'wsu-mediaelement-events', plugins_url( '/js/mediaelement-events.js', __FILE__ ), array( 'mediaelement' ), false, true );
+		wp_enqueue_script( 'wp-mediaelement', '/wp-includes/js/mediaelement/wp-mediaelement.js', array( 'mediaelement' ), false, true );
 	}
 
 	/**

--- a/wsu-analytics.php
+++ b/wsu-analytics.php
@@ -20,7 +20,8 @@ class WSU_Analytics {
 	 */
 	public function __construct() {
 		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
-		add_action( 'wp_enqueue_scripts', array( $this, 'mediaelement_scripts' ), 99 );
+		add_filter( 'wp_video_shortcode_library', array( $this, 'mediaelement_scripts' ), 11 );
+		add_filter( 'wp_audio_shortcode_library', array( $this, 'mediaelement_scripts' ), 11 );
 		add_action( 'admin_init', array( $this, 'display_settings' ) );
 		add_action( 'wp_footer', array( $this, 'global_tracker' ), 999 );
 		add_action( 'admin_footer', array( $this, 'global_tracker' ), 999 );
@@ -104,10 +105,13 @@ class WSU_Analytics {
 
 	public function mediaelement_scripts() {
 		global $wp_scripts;
+
 		wp_deregister_script( 'wp-mediaelement' );
 		$wp_scripts->registered['mediaelement']->extra['data'] = str_replace( '_wpmejsSettings', '_oldwpmejsSettings', $wp_scripts->registered['mediaelement']->extra['data'] );
 		wp_enqueue_script( 'wsu-mediaelement-events', plugins_url( '/js/mediaelement-events.js', __FILE__ ), array( 'mediaelement' ), false, true );
 		wp_enqueue_script( 'wp-mediaelement', '/wp-includes/js/mediaelement/wp-mediaelement.js', array( 'mediaelement' ), false, true );
+
+		return 'mediaelement';
 	}
 
 	/**


### PR DESCRIPTION
At some point we'll want to adjust this and make it more extensible. For now, it works.

We hijack the private-ish `_wpmejsSettings` object provided by core and provide one of our own that includes a success function which attaches events for playing, pausing, and ending audio and video.