### PR TITLE
[PR] set up to inbound and outbound to declare the actions by default

### DIFF
--- a/js/default_events.js
+++ b/js/default_events.js
@@ -102,7 +102,8 @@ window.wsu_analytics.site.events   = [
 		element:"a[href^='http']:not([href*='wsu.edu']), .track.outbound",
 		options:{
 			mode:"event,_link",
-			category:"outbound"
+			category:"outbound",
+			action:"click"
 		}
 	},
 	{
@@ -110,7 +111,8 @@ window.wsu_analytics.site.events   = [
 		options:{
 			skip_internal:"true",
 			mode:"event,_link",
-			category:"internal"
+			category:"internal",
+			action:"click"
 		}
 	},
 	{
@@ -124,7 +126,8 @@ window.wsu_analytics.site.events   = [
 			skip_internal:"true",
 			overwrites:"true",
 			mode:"event",
-			category:"internal-query-intolerant"
+			category:"internal-query-intolerant",
+			action:"click"
 
 		}
 	},
@@ -138,7 +141,8 @@ window.wsu_analytics.site.events   = [
 			skip_internal:"true",
 			overwrites:"true",
 			mode:"event",
-			category:"outbound-query-intolerant"
+			category:"outbound-query-intolerant",
+			action:"click"
 			
 		}
 	},

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "wsuwp-plugin-analytics",
-	"version": "0.4.2",
+	"version": "0.4.3",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/washingtonstateuniversity/wsuwp-plugin-analytics.git"

--- a/wsu-analytics.php
+++ b/wsu-analytics.php
@@ -13,7 +13,7 @@ class WSU_Analytics {
 	/**
 	 * @var string The current version of this plugin. Used to break script cache.
 	 */
-	var $version = '0.4.2';
+	var $version = '0.4.3';
 
 	/**
 	 * @var string Track the string used for the custom settings page we add.


### PR DESCRIPTION
This should fix the issue on the main wsu.edu site where the inbound and outbound is missing in the reports, but were firing.  No issue reported as it was not for sure that it was the plugin's issue.  It may still not be, but it's better to declare it anyways.