### PR TITLE
[PR] Allow only network and global admins to disable analytics

### DIFF
--- a/wsu-analytics.php
+++ b/wsu-analytics.php
@@ -347,12 +347,12 @@ class WSU_Analytics {
 		<label>Yes <input type="radio" class="regular-radio" name="wsuwp_analytics_option_map[track_app]" value="true" <?php checked( 'true', $option_object['track_app'] ); ?> /></label>
 		<label>No  <input type="radio" class="regular-radio" name="wsuwp_analytics_option_map[track_app]" value="false" <?php checked( 'false', $option_object['track_app'] ); ?> /></label>
 		<p class="description">Should WSUWP Platform analytics be tracked on this site? This should normally be on and only disabled for debugging.</p><br/>
-		<?php endif; ?>
 
 		<p><span class="wsu-analytics-label">Track Site Analytics</span></p>
 		<label>Yes <input type="radio" class="regular-radio" name="wsuwp_analytics_option_map[track_site]" value="true" <?php checked( 'true', $option_object['track_site'] ); ?> /></label>
 		<label>No  <input type="radio" class="regular-radio" name="wsuwp_analytics_option_map[track_site]" value="false" <?php checked( 'false', $option_object['track_site'] ); ?> /></label>
 		<p class="description">Should analytics be tracked on this site? A Google Analytics ID is still required if this is enabled.</p><br/>
+		<?php endif; ?>
 
 		<hr/>
 		<p class="description">Instructions on how to set up your Google analytics to best use this plugin can be <a href="https://web.wsu.edu/wordpress/plugins/wsu-analytics/">found here</a>.</p>


### PR DESCRIPTION
Of course, if a site owner were to remove the actual tracker from
the above box, there would be no analytics anyway. :)