### PR TITLE
[PR] Lock jTrack version to 1.2.5

### DIFF
--- a/wsu-analytics.php
+++ b/wsu-analytics.php
@@ -408,7 +408,7 @@ class WSU_Analytics {
 		// be part of a must-use plugin.
 		$app_analytics_id = apply_filters( 'wsu_analytics_app_analytics_id', '' );
 
-		wp_enqueue_script( 'jquery-jtrack', '//repo.wsu.edu/jtrack/1/jtrack.min.js', array( 'jquery' ), $this->script_version(), true );
+		wp_enqueue_script( 'jquery-jtrack', '//repo.wsu.edu/jtrack/1.2.5/jtrack.min.js', array( 'jquery' ), $this->script_version(), true );
 
 		wp_register_script( 'wsu-analytics-main', plugins_url( 'js/analytics.min.js', __FILE__ ), array( 'jquery-jtrack', 'jquery' ), $this->script_version(), true );
 


### PR DESCRIPTION
This allows us to use a specific version of jTrack while testing the new develop version. A future commit should allow for the swapping of versions on an individual site level.