### PR TITLE
[PR] Remove `wsuwp_get_current_network()` and related functions

### DIFF
--- a/wsu-analytics.php
+++ b/wsu-analytics.php
@@ -367,7 +367,7 @@ class WSU_Analytics {
 		<label>No <input type="radio" class="regular-radio" name="wsuwp_analytics_option_map[use_jquery_ui]" value="false" <?php checked( 'false', $option_object['use_jquery_ui'] )?> /></label>
 		<p class="description">Should WSU Analytics track default jQuery UI events for the site?</p><br/>
 
-		<?php if ( ( function_exists( 'wsuwp_is_network_admin' ) && wsuwp_is_network_admin( wsuwp_get_current_network() ) ) || is_super_admin() ) : ?>
+		<?php if ( ( function_exists( 'wsuwp_is_global_admin' ) && wsuwp_is_global_admin( wp_get_current_user()->ID ) ) || is_super_admin() ) : ?>
 		<p><span class="wsu-analytics-label">Track Global Analytics</span></p>
 		<label>Yes <input type="radio" class="regular-radio" name="wsuwp_analytics_option_map[track_global]" value="true" <?php checked( 'true', $option_object['track_global'] ); ?> /></label>
 		<label>No  <input type="radio" class="regular-radio" name="wsuwp_analytics_option_map[track_global]" value="false" <?php checked( 'false', $option_object['track_global'] ); ?> /></label>

--- a/wsu-analytics.php
+++ b/wsu-analytics.php
@@ -490,8 +490,8 @@ class WSU_Analytics {
 			$spine_grid = esc_js( spine_get_option( 'grid_style' ) );
 		}
 
-		if ( function_exists( 'wsuwp_get_current_network' ) ) {
-			$wsuwp_network = wsuwp_get_current_network()->domain;
+		if ( is_multisite() ) {
+			$wsuwp_network = get_network()->domain;
 		}
 
 		// Escaping of tracker data for output as JSON is handled via wp_localize_script().


### PR DESCRIPTION
This removes the use of `wsuwp_get_current_network()` and uses `get_network()` instead. The previous check for whether a user was a network admin was broken because the wrong parameters were being passed to `wsuwp_is_network_admin()`. That's been changed to check for a global admin instead.

See https://github.com/washingtonstateuniversity/WSUWP-Platform/issues/350